### PR TITLE
Rename OpsSmithUtils references to SqlBakeUtils

### DIFF
--- a/SQLBaker.php
+++ b/SQLBaker.php
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 /**
- * DevOpsToolSmith Database management tool - SqlBake();
+ * SqlBake – Database management tool
  *
  * Utility to take stored procs and tables and save to SQL files
  * Ability to load SQL alter and patch scripts for deployment.
@@ -16,9 +16,9 @@ if (file_exists($autoloadFile)) {
     require $autoloadFile;
 }
 
-use DevOpsToolSmith\OpsSmithUtils;
+use SqlBake\SqlBakeUtils;
 
-$utility = new OpsSmithUtils();
+$utility = new SqlBakeUtils();
 
 // Command-line argument handling
 $shortOptions = "p:t:r:d:s:";


### PR DESCRIPTION
## Summary
- update banner comment to use SqlBake branding
- replace OpsSmithUtils with SqlBakeUtils import
- instantiate SqlBakeUtils instead of OpsSmithUtils

## Testing
- `php -l SQLBaker.php`


------
https://chatgpt.com/codex/tasks/task_e_689be0c6cd44832b9b4bf49a92edf8b2