### PR TITLE
chore: update branding and config traits

### DIFF
--- a/etc/config.common.php
+++ b/etc/config.common.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DevOpsToolSmith Database management tool - SqlBake();
+ * SqlBake – Database management tool
  *
  * Utility to take stored procs and tables and save to SQL files
  * Ability to load SQL alter and patch scripts for deployment.
@@ -22,9 +22,9 @@ require_once(__DIR__ . '/../lib/db.base.class.php');
 require_once(__DIR__ . '/../lib/db.utils.class.php');
 require_once(__DIR__ . '/../lib/common.utils.class.php');
 
-use DevOpsToolSmith\ConfigTraits;
-use DevOpsToolSmith\DBBase;
-use DevOpsToolSmith\DBUtils;
-use DevOpsToolSmith\CommonUtils;
+use SqlBake\ConfigTraits;
+use SqlBake\DBBase;
+use SqlBake\DBUtils;
+use SqlBake\CommonUtils;
 
 

--- a/etc/config.traits.php
+++ b/etc/config.traits.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DevOpsToolSmith Database management tool - SqlBake();
+ * SqlBake – Database management tool
  *
  * Utility to take stored procs and tables and save to SQL files
  * Ability to load SQL alter and patch scripts for deployment.
@@ -8,11 +8,11 @@
  */
 
 /**
- * Trait OpsSmithDBConfig
+ * Trait SqlBakeDBConfig
  *
  * Config objects for db abstraction layer and system configurations
  */
-trait OpsSmithDBConfig{
+trait SqlBakeDBConfig{
 
     public function db_manager_host(){
         return "prod-db-manager";
@@ -74,9 +74,9 @@ trait OpsSmithDBConfig{
 }
 
 /**
- * Trait OpsSmithConfig
+ * Trait SqlBakeConfig
  */
-trait OpsSmithConfig{
+trait SqlBakeConfig{
 
     public function get_env(){
         return ENV;

--- a/lib/common.utils.class.php
+++ b/lib/common.utils.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DevOpsToolSmith Database management tool - SqlBake();
+ * SqlBake – Database management tool
  *
  * Utility to take stored procs and tables and save to sql files
  * Ability to load sql alter and patch scripts for deployment.
@@ -10,12 +10,12 @@
 
 /**
  * Class OpsSmithUtils
- * @uses DevOpsToolSmithDb
- */
-class OpsSmithUtils extends DevOpsToolSmithDb
+ * @uses SqlBakeDb
+*/
+class OpsSmithUtils extends SqlBakeDb
 {
-    use OpsSmithDBConfig;
-    use OpsSmithConfig;
+    use SqlBakeDBConfig;
+    use SqlBakeConfig;
 
     public $base_path = "./databases";
 
@@ -27,7 +27,7 @@ class OpsSmithUtils extends DevOpsToolSmithDb
     public function cmd__sync($fromdb, $todb, $databases)
     {
         if (!in_array($fromdb, $databases)) {
-            echo "syncing from hotfix by default to DevOpsToolSmith\n";
+            echo "syncing from hotfix by default to SqlBake\n";
             return;
         }
 
@@ -70,7 +70,7 @@ class OpsSmithUtils extends DevOpsToolSmithDb
 
                 default:
                     if ($this->get_env() == ENV_LOCAL) {
-                        echo "deploying to portal.DevOpsToolSmith.int\n";
+                        echo "deploying to portal.SqlBake.int\n";
                     }
             }
         } catch (Exception $e) {

--- a/lib/db.base.class.php
+++ b/lib/db.base.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DevOpsToolSmith Database management tool - SqlBake();
+ * SqlBake – Database management tool
  *
  * Utility to take stored procs and tables and save to sql files
  * Ability to load sql alter and patch scripts for deployment.
@@ -13,9 +13,9 @@
  *
  * @author davestj@gmail.com
  *
- * Class DevOpsToolSmithDb
+ * Class SqlBakeDb
  */
-class DevOpsToolSmithDb extends PDO {
+class SqlBakeDb extends PDO {
     /**
      * @var string|null
      */

--- a/lib/db.utils.class.php
+++ b/lib/db.utils.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DevOpsToolSmith Database management tool - SqlBake();
+ * SqlBake – Database management tool
  *
  * Utility to take stored procs and tables and save to sql files
  * Ability to load sql alter and patch scripts for deployment.
@@ -13,9 +13,9 @@
  */
 class OpsSmithdbTableManager extends legacyDb{
     /**
-     * using trait OpsSmithDBConfig;
+     * using trait SqlBakeDBConfig;
      */
-    use OpsSmithDBConfig;
+    use SqlBakeDBConfig;
 
     /**
      * @var array
@@ -233,9 +233,9 @@ class OpsSmithdbTableManager extends legacyDb{
  */
 class OpsSmithdbProcManager extends legacyDb{
     /**
-     * using trait OpsSmithDBConfig;
+     * using trait SqlBakeDBConfig;
      */
-    use OpsSmithDBConfig;
+    use SqlBakeDBConfig;
 
     /**
      * @var array


### PR DESCRIPTION
## Summary
- replace file headers with `SqlBake – Database management tool`
- rename config traits to `SqlBakeDBConfig` and `SqlBakeConfig`
- swap `DevOpsToolSmith` references for `SqlBake` in use statements and base DB class

## Testing
- `php -l lib/db.base.class.php && php -l lib/common.utils.class.php && php -l lib/db.utils.class.php && php -l etc/config.traits.php && php -l etc/config.common.php`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_689bea1063d0832bb83254156a827415