### PR TITLE
chore: rename OpsSmithUtils to SqlBakeUtils

### DIFF
--- a/etc/config.common.php
+++ b/etc/config.common.php
@@ -25,6 +25,6 @@ require_once(__DIR__ . '/../lib/common.utils.class.php');
 use SqlBake\ConfigTraits;
 use SqlBake\DBBase;
 use SqlBake\DBUtils;
-use SqlBake\CommonUtils;
+use SqlBake\SqlBakeUtils;
 
 

--- a/lib/common.utils.class.php
+++ b/lib/common.utils.class.php
@@ -9,10 +9,10 @@
  */
 
 /**
- * Class OpsSmithUtils
+ * Class SqlBakeUtils
  * @uses SqlBakeDb
 */
-class OpsSmithUtils extends SqlBakeDb
+class SqlBakeUtils extends SqlBakeDb
 {
     use SqlBakeDBConfig;
     use SqlBakeConfig;


### PR DESCRIPTION
## Summary
- rename OpsSmithUtils class to SqlBakeUtils and update docblock
- update config to import SqlBakeUtils

## Testing
- `php -l lib/common.utils.class.php`
- `php -l etc/config.common.php`
- `php -l SQLBaker.php`


------
https://chatgpt.com/codex/tasks/task_e_689c108759dc832b9ab5812d83f9a350