### PR TITLE
Rename OpsSmith managers to SqlBake and update headers

### DIFF
--- a/SQLBaker.php
+++ b/SQLBaker.php
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 /**
- * SqlBake – Database management tool
+ * SqlBake
  *
  * Utility to take stored procs and tables and save to SQL files
  * Ability to load SQL alter and patch scripts for deployment.

--- a/etc/config.common.php
+++ b/etc/config.common.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SqlBake – Database management tool
+ * SqlBake
  *
  * Utility to take stored procs and tables and save to SQL files
  * Ability to load SQL alter and patch scripts for deployment.

--- a/etc/config.traits.php
+++ b/etc/config.traits.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SqlBake – Database management tool
+ * SqlBake
  *
  * Utility to take stored procs and tables and save to SQL files
  * Ability to load SQL alter and patch scripts for deployment.
@@ -8,11 +8,11 @@
  */
 
 /**
- * Trait SqlBakeDBConfig
+ * Trait SqlBakeDbConfig
  *
  * Config objects for db abstraction layer and system configurations
  */
-trait SqlBakeDBConfig{
+trait SqlBakeDbConfig{
 
     public function db_manager_host(){
         return "prod-db-manager";

--- a/lib/common.utils.class.php
+++ b/lib/common.utils.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SqlBake – Database management tool
+ * SqlBake
  *
  * Utility to take stored procs and tables and save to sql files
  * Ability to load sql alter and patch scripts for deployment.
@@ -14,7 +14,7 @@
 */
 class SqlBakeUtils extends SqlBakeDb
 {
-    use SqlBakeDBConfig;
+    use SqlBakeDbConfig;
     use SqlBakeConfig;
 
     public $base_path = "./databases";
@@ -389,7 +389,7 @@ class SqlBakeUtils extends SqlBakeDb
             switch ($value) {
                 case 'list':
                     echo "dumping proc list\n";
-                    $p       = new OpsSmithdbProcManager();
+                    $p       = new SqlBakeDbProcManager();
                     $proclist = $p->get_proc_list();
                     foreach ($proclist as $theproc) {
                         $procsql = $p->get_proc_by_name($theproc);
@@ -400,7 +400,7 @@ class SqlBakeUtils extends SqlBakeDb
 
                 case  'save':
                     echo "saving all procs to disk\n";
-                    $p       = new OpsSmithdbProcManager();
+                    $p       = new SqlBakeDbProcManager();
                     $proclist = $p->get_proc_list();
                     foreach ($proclist as $theproc) {
                         $procsql = $p->get_proc_by_name($theproc);
@@ -411,12 +411,12 @@ class SqlBakeUtils extends SqlBakeDb
 
                 case  'clean':
                     echo "cleaning all procs on disk\n";
-                    $p       = new OpsSmithdbProcManager();
+                    $p       = new SqlBakeDbProcManager();
                     $cleanit = $p->clean_procs();
                     break;
 
                 case  'load':
-                    $p            = new OpsSmithdbProcManager();
+                    $p            = new SqlBakeDbProcManager();
                     $proclistfs  = $p->get_proc_list_from_fs();
                     echo "loading all procs.sql files on disk to mysql server\n";
                     foreach ($proclistfs as $theproc) {
@@ -439,7 +439,7 @@ class SqlBakeUtils extends SqlBakeDb
             switch ($value) {
                 case 'show':
                     echo "dumping table list name and raw sql\n";
-                    $t          = new OpsSmithdbTableManager();
+                    $t          = new SqlBakeDbTableManager();
                     $tablelist = $t->get_tables_list();
                     foreach ($tablelist as $thetable) {
                         $tablesql = $t->get_table_by_name($thetable, false);
@@ -450,7 +450,7 @@ class SqlBakeUtils extends SqlBakeDb
 
                 case 'list':
                     echo "showing table list from filesystem\n";
-                    $t         = new OpsSmithdbTableManager();
+                    $t         = new SqlBakeDbTableManager();
                     $tablelist = $t->get_table_list_from_fs();
                     foreach ($tablelist as $thetable) {
                         echo "\e[1;32m\ntable name: $thetable \e[0m\n";
@@ -458,7 +458,7 @@ class SqlBakeUtils extends SqlBakeDb
                     break;
 
                 case  'save':
-                    $t          = new OpsSmithdbTableManager();
+                    $t          = new SqlBakeDbTableManager();
                     $tablelist = $t->get_tables_list();
                     echo "saving all tables to disk\n";
                     foreach ($tablelist as $thetable) {
@@ -470,12 +470,12 @@ class SqlBakeUtils extends SqlBakeDb
 
                 case  'clean':
                     echo "cleaning all tables on disk\n";
-                    $t       = new OpsSmithdbTableManager();
+                    $t       = new SqlBakeDbTableManager();
                     $cleanit = $t->clean_tables();
                     break;
 
                 case  'load':
-                    $t            = new OpsSmithdbTableManager();
+                    $t            = new SqlBakeDbTableManager();
                     $tablelistfs = $t->get_table_list_from_fs();
                     echo "loading all table.sql files on disk to mysql server\n";
                     foreach ($tablelistfs as $thetable) {

--- a/lib/db.base.class.php
+++ b/lib/db.base.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SqlBake – Database management tool
+ * SqlBake
  *
  * Utility to take stored procs and tables and save to sql files
  * Ability to load sql alter and patch scripts for deployment.

--- a/lib/db.utils.class.php
+++ b/lib/db.utils.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SqlBake – Database management tool
+ * SqlBake
  *
  * Utility to take stored procs and tables and save to sql files
  * Ability to load sql alter and patch scripts for deployment.
@@ -9,13 +9,13 @@
  */
 
 /**
- * Class OpsSmithdbTableManager
+ * Class SqlBakeDbTableManager
  */
-class OpsSmithdbTableManager extends legacyDb{
+class SqlBakeDbTableManager extends legacyDb{
     /**
-     * using trait SqlBakeDBConfig;
+     * using trait SqlBakeDbConfig;
      */
-    use SqlBakeDBConfig;
+    use SqlBakeDbConfig;
 
     /**
      * @var array
@@ -229,13 +229,13 @@ class OpsSmithdbTableManager extends legacyDb{
 }
 
 /**
- * Class OpsSmithdbProcManager
+ * Class SqlBakeDbProcManager
  */
-class OpsSmithdbProcManager extends legacyDb{
+class SqlBakeDbProcManager extends legacyDb{
     /**
-     * using trait SqlBakeDBConfig;
+     * using trait SqlBakeDbConfig;
      */
-    use SqlBakeDBConfig;
+    use SqlBakeDbConfig;
 
     /**
      * @var array


### PR DESCRIPTION
## Summary
- Rename OpsSmithdbTableManager -> SqlBakeDbTableManager and OpsSmithdbProcManager -> SqlBakeDbProcManager
- Rename SqlBakeDBConfig trait to SqlBakeDbConfig and update uses
- Standardize file headers to `SqlBake`

## Testing
- `php -l etc/config.traits.php`
- `php -l lib/db.utils.class.php`
- `php -l lib/common.utils.class.php`
- `php -l SQLBaker.php`
- `php -l etc/config.common.php`
- `php -l lib/db.base.class.php`


------
https://chatgpt.com/codex/tasks/task_e_689c12c37200832ba6b264f35648d202